### PR TITLE
Add terms of service functionality

### DIFF
--- a/packages/components/src/registration/SignUpForm.tsx
+++ b/packages/components/src/registration/SignUpForm.tsx
@@ -12,6 +12,7 @@ import { Button } from "@good-dog/ui/button";
 import EmailVerifyModal from "./EmailVerifyModal";
 import GenericRegistrationForm from "./GenericRegistrationForm";
 import RegistrationInput from "./inputs/RegistrationInput";
+import TOSModal from "./TOSModal";
 
 const zSignUpValues = z.object({
   emailConfirmed: z.string(),
@@ -54,6 +55,7 @@ export default function SignUpForm() {
 
   const [isEmailVerificationModalOpen, setIsEmailVerificationModalOpen] =
     useState(false);
+  const [isTOSModalOpen, setIsTOSModalOpen] = useState(false);
   const sendVerificationEmailMutation = trpc.sendEmailVerification.useMutation({
     onSuccess: (data) => {
       switch (data.status) {
@@ -105,6 +107,7 @@ export default function SignUpForm() {
   const isEmailVerified =
     sendVerificationEmailMutation.isSuccess &&
     signUpForm.watch("emailConfirmed") === email;
+  const [acceptedTOS, setAcceptedTOS] = useState(false);
 
   return (
     <FormProvider {...signUpForm}>
@@ -116,12 +119,23 @@ export default function SignUpForm() {
           }}
         />
       )}
+      {isTOSModalOpen && (
+        <TOSModal
+          close={() => {
+            setIsTOSModalOpen(false);
+          }}
+          accept={() => {
+            setIsTOSModalOpen(false);
+            setAcceptedTOS(true);
+          }}
+        />
+      )}
       <GenericRegistrationForm
         title="Sign Up"
         variant="dark"
         ctaTitle="Sign Up"
         onSubmit={onSubmitSignUp}
-        disabled={!isEmailVerified}
+        disabled={!isEmailVerified || !acceptedTOS}
         secondaryAction="Already have an account?"
         secondaryActionLink="Sign In"
         secondaryActionUrl="/login"
@@ -193,6 +207,17 @@ export default function SignUpForm() {
             classname="flex-1"
           />
         </div>
+        <Button
+          className="h-4 w-full rounded-full"
+          onClick={(e) => {
+            // prevent actual <form/> submission
+            e.preventDefault();
+            // Open TOS modal
+            setIsTOSModalOpen(true);
+          }}
+        >
+          View & Accept TOS
+        </Button>
       </GenericRegistrationForm>
     </FormProvider>
   );

--- a/packages/components/src/registration/TOSModal.tsx
+++ b/packages/components/src/registration/TOSModal.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { Button } from "@good-dog/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@good-dog/ui/dialog";
+
+export default function TOSModal({
+  isOpen = true,
+  close,
+  accept,
+}: {
+  isOpen?: boolean;
+  close: () => void;
+  accept: () => void;
+}) {
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          close();
+        }
+      }}
+    >
+      <DialogContent className="max-h-[700px] overflow-y-scroll border-black sm:max-w-[912px]">
+        <DialogHeader>
+          <DialogTitle>View & Accept TOS</DialogTitle>
+          <DialogDescription className="font-afacad text-s p-7 text-center font-normal text-good-dog-violet">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nisl
+            sem, dapibus non tortor auctor, maximus auctor mauris. Donec id odio
+            suscipit, pharetra felis a, cursus elit. Donec in lacus felis.
+            Praesent egestas venenatis bibendum. Aenean mollis nibh in tortor
+            rhoncus mollis. Etiam pellentesque felis eget arcu tempus suscipit.
+            Duis condimentum, ipsum vitae fermentum pharetra, risus tortor
+            interdum erat, ac mollis sem tellus at risus. Mauris euismod auctor
+            tellus. Nunc dapibus, nisl eu vestibulum scelerisque, elit nulla
+            hendrerit risus, id euismod metus dolor ut diam. Fusce pulvinar
+            aliquet nunc congue auctor. In hac habitasse platea dictumst. Aenean
+            tempus ipsum at metus auctor pulvinar. Nullam volutpat posuere
+            felis, nec volutpat turpis dapibus vitae. Fusce facilisis sit amet
+            eros quis condimentum. Suspendisse sit amet ultrices sapien. Nullam
+            tellus diam, pellentesque sed imperdiet sed, faucibus quis elit.
+            Aenean id nunc non est tempus facilisis. Proin rhoncus nibh nulla,
+            eu tempor urna dictum eget. Fusce interdum lorem in lorem pretium,
+            et sollicitudin felis facilisis. Sed imperdiet ex nec ante pharetra,
+            eu pulvinar augue feugiat. Quisque nulla arcu, rutrum a elementum
+            fermentum, ullamcorper nec felis. Suspendisse potenti. Etiam congue
+            sagittis sapien ac mollis. Aliquam nunc ipsum, bibendum sit amet
+            suscipit id, porta et magna. Praesent tristique at diam eget
+            pretium. Mauris est odio, elementum ut turpis nec, rhoncus varius
+            ipsum. Sed non laoreet ante, sed sagittis turpis. Nam id diam
+            accumsan, porttitor augue ut, placerat metus. Aenean posuere rhoncus
+            nunc in commodo. Duis iaculis rutrum turpis. Vivamus fringilla
+            efficitur arcu ac hendrerit. Phasellus dapibus lobortis nisl quis
+            dapibus. Aliquam varius, augue nec auctor pharetra, augue nisl
+            tristique nulla, at ultricies ligula augue a erat. Nunc egestas mi
+            in enim blandit bibendum. Nulla et sem ligula. Morbi pulvinar augue
+            nisi, ac finibus est sagittis in. Cras euismod dui egestas nisi
+            tristique, nec bibendum nibh feugiat. Morbi viverra elit in sem
+            pharetra cursus. Duis a est dapibus, dignissim ligula quis,
+            facilisis nisi. Phasellus in fringilla ipsum, ac lobortis dolor. Ut
+            at bibendum erat, sit amet pellentesque ex. Cras eget felis quam.
+            Sed nec faucibus ante, sed aliquet nisi. Donec eleifend aliquam
+            dapibus. Suspendisse imperdiet tincidunt ante, quis lacinia ex
+            tempor sed. Fusce efficitur nisi id tortor porttitor luctus. Donec
+            dictum, ipsum vel hendrerit tempus, turpis neque ullamcorper augue,
+            sit amet tincidunt dolor nibh vitae purus. Ut egestas sollicitudin
+            posuere. Curabitur non ex augue. Vivamus non sapien sed orci
+            sollicitudin pulvinar ut non eros. Donec finibus, arcu vel imperdiet
+            maximus, lacus ex interdum sapien, sit amet egestas neque massa vel
+            ex. Nulla facilisi. Nulla posuere nisi quis finibus faucibus. In
+            lorem lacus, congue vitae blandit nec, condimentum ut arcu.
+            Pellentesque habitant morbi tristique senectus et netus et malesuada
+            fames ac turpis egestas. Quisque consequat maximus orci, eget
+            sodales turpis aliquam sollicitudin. Curabitur lobortis sapien
+            dolor, in consectetur lectus tristique id. Sed et luctus dolor.
+            Suspendisse fringilla, ligula vitae tempus rhoncus, leo ipsum
+            sollicitudin ex, sed varius lorem ipsum vitae dui. Proin tempus
+            ligula ex, non malesuada ipsum tempus efficitur. Cras in lectus sit
+            amet enim dapibus dictum at eget mauris. Donec viverra neque ac
+            tincidunt aliquet. In finibus quam augue, eget ultricies leo euismod
+            at. Duis et felis vel dui ullamcorper placerat vel et massa. Proin
+            lacinia ante ut eros molestie, ac hendrerit dui tristique. Orci
+            varius natoque penatibus et magnis dis parturient montes, nascetur
+            ridiculus mus. Vivamus venenatis velit quis urna mollis, eu
+            scelerisque ex placerat. Nunc odio ligula, volutpat et dolor ut,
+            ornare convallis purus. In sit amet augue sem. Aenean convallis
+            auctor enim consequat feugiat. Nam in arcu id velit dapibus accumsan
+            ullamcorper quis massa. Mauris rhoncus turpis non mollis euismod.
+            Donec consectetur bibendum risus, eu venenatis risus vulputate
+            accumsan. Fusce tempus enim metus, sit amet feugiat dolor suscipit
+            nec. Interdum et malesuada fames ac ante ipsum primis in faucibus.
+            Etiam suscipit libero non arcu volutpat hendrerit. Nam tempus
+            vestibulum ultricies. Nulla at molestie felis. Duis orci lacus,
+            interdum a lobortis vel, mattis ut leo. Aliquam erat volutpat. Donec
+            elementum, arcu a ultricies dignissim, ipsum enim porttitor nulla,
+            ac lacinia ex leo ut tellus. Cras a tempor enim. Proin placerat
+            faucibus euismod. Aenean quis justo est. Nam enim mi, tincidunt eu
+            tortor nec, volutpat efficitur ex. Quisque sit amet nibh malesuada,
+            placerat metus ac, aliquam ipsum. Morbi posuere tellus sed metus
+            imperdiet dapibus. Aliquam porttitor id mauris nec tristique. Fusce
+            sit amet lacinia massa. Donec ultrices ante sollicitudin nibh
+            egestas, vel molestie purus pretium. Proin vel tellus molestie,
+            consectetur ipsum a, malesuada nunc. Proin neque diam, euismod quis
+            ullamcorper quis, porta a est. Duis aliquet urna at ante elementum,
+            non vulputate ipsum posuere. Integer vel gravida quam, sed malesuada
+            metus. Pellentesque venenatis, metus at venenatis efficitur, justo
+            lorem feugiat turpis, eget porttitor velit eros sit amet massa. Ut
+            egestas elit quis turpis faucibus condimentum. Nulla sit amet ante
+            in lacus consectetur aliquet vel at urna.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={accept}>
+          <DialogFooter>
+            <Button type="submit">Accept</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Description

Implemented functionality for viewing and accepting terms of service. When the view & accept button is clicked, a modal opens to read and click 'accept.' If not clicked, the user will not be allowed to sign up. Currently the TOS text is LI.

## Motivation and Context

Addresses #42 

## Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Global styling changes
- [ ] New package(s)
- [ ] New dependencies
- [ ] Project configuration
- [ ] Environment variable update
- [ ] Database migration
- [ ] CI/CD changes (changing github actions or deployment scripts)

## Checklist:

- [x] I verified my changes work in the local environment
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I verified my changes work in the preview environment

## How has this been tested?

Tested locally. 

## Screenshots (if appropriate):
<img width="1409" alt="Screen Shot 2025-02-23 at 11 36 18 AM" src="https://github.com/user-attachments/assets/d1a6cbff-ff06-4093-827a-1956499b017d" />

<img width="1407" alt="Screen Shot 2025-02-23 at 11 36 42 AM" src="https://github.com/user-attachments/assets/7ace37ff-4080-4ce2-a43c-0eb55fe3618a" />

<img width="1408" alt="Screen Shot 2025-02-23 at 11 37 33 AM" src="https://github.com/user-attachments/assets/b8c2a9df-9613-46b0-8377-3ca1c0088fcf" />
