### PR TITLE
Clean up overlapping styles

### DIFF
--- a/apps/web/app/(pages)/layout.tsx
+++ b/apps/web/app/(pages)/layout.tsx
@@ -19,7 +19,7 @@ export default function Layout({
             {children}
           </div>
         </div>
-        <div className="h-[100px] bg-[#07634C]" />
+        <div className="h-[100px] bg-good-dog-main" />
       </ClientWrapper>
     </HydrateClient>
   );

--- a/apps/web/app/(pages)/page.tsx
+++ b/apps/web/app/(pages)/page.tsx
@@ -23,7 +23,7 @@ export default function Home() {
               <div className="flex gap-4 justify-center">
                 <Button
                   size="large-text"
-                  className="bg-dark-green text-off-white shadow-button"
+                  className="bg-good-dog-main text-off-white shadow-button"
                   onClick={() => router.push("/login")}
                 >
                   Get started
@@ -115,7 +115,7 @@ export function DescriptionSection({
   );
 }
 
-function VerticalDescriptionSection({
+export function VerticalDescriptionSection({
   title,
   text,
   link,
@@ -126,8 +126,6 @@ function VerticalDescriptionSection({
   link: () => void;
   linkText: string;
 }) {
-  //const router = useRouter();
-
   return (
     <div className="flex flex-col gap-[24px] text-center justify-center items-center">
       <SampleImage />
@@ -143,47 +141,3 @@ function VerticalDescriptionSection({
 function SampleImage() {
   return <div className="w-[250px] h-[250px] bg-gray-400 rounded-[20px]"></div>;
 }
-
-// export default function Home() {
-//   return (
-//     <main className="bg-good-dog-violet">
-//       <Splash />
-//       <LandingSubmission />
-//       <LandingSubmission
-//         flipX
-//         flipY
-//         reverseLayout
-//         title="Musicians"
-//         description="Your music should be heard! Good Dog Licensing is all about expanding your audience and bringing your music to new heights. Artists retain 100% of all rights when they license through Good Dog! All filmmakers are required to fill out cue sheets as well, so we offer artists a chance at earning backend royalties. With no extra work for you whatsoever, Good Dog can help you reach new listeners and make great new connections within the entertainment industry!"
-//         button="SEND US YOUR MUSIC"
-//       />
-//       <ProjectGallery />
-//     </main>
-//   );
-// }
-
-// const Splash = () => {
-//   return (
-//     <div className="pb-60 pt-36">
-//       <Image
-//         src="/icons/Good Dog With Logo.svg"
-//         width={789}
-//         height={0}
-//         alt="good-dog-logo"
-//         className="m-auto mb-6 block"
-//       />
-
-//       <div className="font-regular m-auto mb-6 w-fit font-righteous text-2xl text-good-dog-celadon">
-//         "Connecting Creatives"
-//       </div>
-
-//       <div className="font-regular m-auto w-fit font-righteous text-good-dog-violet">
-//         <Link href="/submit">
-//           <div className="rounded-full bg-good-dog-celadon px-6 py-2 text-5xl">
-//             SUBMIT A BRIEF
-//           </div>
-//         </Link>
-//       </div>
-//     </div>
-//   );
-// };

--- a/apps/web/app/(registration)/layout.tsx
+++ b/apps/web/app/(registration)/layout.tsx
@@ -1,7 +1,5 @@
 export default function Layout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
-  return (
-    <div className="bg-main-gradient px-[228px] min-w-[1250px]">{children}</div>
-  );
+  return <div className="px-[228px] min-w-[1250px]">{children}</div>;
 }

--- a/packages/components/src/svg/NavLogo.tsx
+++ b/packages/components/src/svg/NavLogo.tsx
@@ -8,7 +8,7 @@ export default function NavLogo() {
         viewBox="0 0 34 34"
         fill="none"
       >
-        <circle cx="17" cy="17" r="17" fill="#07634C" />
+        <circle cx="17" cy="17" r="17" fill="good-dog-main" />
       </svg>
       <svg
         className="absolute"

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -29,7 +29,6 @@ enum MatchState {
   APPROVED_BY_MUSICIAN
 }
 
-
 model User {
   userId             String              @id @default(uuid()) @map("id")
   email              String              @unique

--- a/packages/ui/shad/radio-group.tsx
+++ b/packages/ui/shad/radio-group.tsx
@@ -31,7 +31,7 @@ const RadioGroupItem = React.forwardRef<
     >
       <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
         <svg>
-          <circle cx="7" cy="7" r="4" fill="#07634C" />
+          <circle cx="7" cy="7" r="4" fill="good-dog-main" />
         </svg>
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>

--- a/tooling/tailwind/base.ts
+++ b/tooling/tailwind/base.ts
@@ -4,10 +4,6 @@ import { fontFamily } from "tailwindcss/defaultTheme";
 export default {
   content: ["src/**/*.{ts,tsx}"],
   theme: {
-    backgroundImage: {
-      "custom-gradient":
-        "linear-gradient(180deg, #FFFBF6 29.69%, #E9F8EC 55.49%, #D3F4E2 96.78%)",
-    },
     extend: {
       fontFamily: {
         sans: ["var(--font-sans)", ...fontFamily.sans],
@@ -40,8 +36,8 @@ export default {
         div: "16px 12px 0px 0px var(--carddrop-shadow, #098465)",
       },
       backgroundImage: {
-        "main-gradient":
-          "var(--Background-light-gradient, linear-gradient(180deg, var(--cream-300, #FFFBF6) 29.69%, #E9F7EC 55.49%, var(--mint-300, #D3F4E2) 96.78%))",
+        "custom-gradient":
+          "linear-gradient(180deg, #FFFBF6 29.69%, #E9F8EC 55.49%, #D3F4E2 96.78%)",
       },
     },
   },

--- a/tooling/tailwind/styles.css
+++ b/tooling/tailwind/styles.css
@@ -8,7 +8,7 @@
 @layer base {
   body {
     font-family: "Afacad", sans-serif;
-    color: text-body-primary;
+    color: #2e2e2e;
     font-feature-settings:
       "rlig" 1,
       "calt" 1;
@@ -19,11 +19,11 @@
     font-size: 75px;
     font-weight: 400;
     line-height: 80px;
-    color: text-body-primary;
+    color: #2e2e2e;
   }
 
   h2 {
-    color: text-body-primary;
+    color: #2e2e2e;
     font-size: 40px;
     font-weight: 500;
     letter-spacing: 0;


### PR DESCRIPTION
## Description

Cleans up a couple of styles that were duplicated between frontend prs for demo day.

## GitHub Issue
None, cleanup
## Type of changes

<!--- Select all that apply -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Global styling changes
- [ ] New package(s)
- [ ] New dependencies
- [ ] Project configuration
- [ ] Environment variable update
- [ ] Database migration
- [ ] CI/CD changes (changing github actions or deployment scripts)

## How has this been tested?

Checked that styles looked the same before and after each change.

## Screenshots (if appropriate):

## Checklist:

<!--- Select all that apply -->

- [X] I verified my changes work in the local environment
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] I verified my changes work in the preview environment
