### PR TITLE
Added the link icon to song request dashboard

### DIFF
--- a/packages/components/src/meda-maker-matching/components/Match.tsx
+++ b/packages/components/src/meda-maker-matching/components/Match.tsx
@@ -1,5 +1,5 @@
 import type { GetProcedureOutput } from "@good-dog/trpc/types";
-import { Check, ChevronRight, X } from "lucide-react";
+import { Check, ChevronRight, Link, X } from "lucide-react";
 import { trpc } from "@good-dog/trpc/client";
 import { useState } from "react";
 import { formatAllCapsList } from "../../../utils/allCapsListFormatter";
@@ -84,13 +84,17 @@ export function Match({
           </div>
           <div className="flex flex-col gap-[6px] text-left">
             <p className="text-gray-500">Link</p>
-            <a
-              className="underline"
-              href={match.musicSubmission.songLink}
-              target="_blank"
-            >
-              View Song
-            </a>
+            <div className="flex flex-row gap-1 text-secondary font-extrabold items-center">
+              <Link size={16} />
+              <a
+                href={match.musicSubmission.songLink}
+                target="_blank"
+                rel="noreferrer"
+                className="underline underline-offset-4"
+              >
+                View Song
+              </a>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Description

<!--- What does this PR do? -->

This adds a link icon to the match info on the song request dashboard

## GitHub Issue

<!--- Enter the issue number here. If there is no issue, create one first. -->

Closes #355

## Type of changes

<!--- Select all that apply -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Global styling changes
- [ ] New package(s)
- [ ] New dependencies
- [ ] Project configuration
- [ ] Environment variable update
- [ ] Database migration
- [ ] CI/CD changes (changing github actions or deployment scripts)

## Screenshots (if appropriate):
<img width="1045" height="247" alt="Screenshot 2026-01-18 at 3 42 23 PM" src="https://github.com/user-attachments/assets/e5f3928c-5099-4c8f-9c64-89dac4f6c06e" />


## Checklist:

<!--- Select all that apply -->

- [x] I verified my changes work in the local environment
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I verified my changes work in the preview environment
