### PR TITLE
Fix status prompts visibility

### DIFF
--- a/packages/components/src/matching/components/Matches.tsx
+++ b/packages/components/src/matching/components/Matches.tsx
@@ -39,9 +39,11 @@ export function Matches({
 
   return (
     <div className="flex flex-col gap-4">
-      <p className="w-full text-dark-gray-500 dark:text-mint-200">
-        Review and approve/deny the songs matched below
-      </p>
+      {filteredMatches.length > 0 && state === "SUGGESTED" && (
+        <p className="w-full text-dark-gray-500 dark:text-mint-200">
+          Review and approve/deny the songs matched below
+        </p>
+      )}
       {filteredMatches.length === 0 && (
         <div className="mt-16 flex w-full flex-col items-center gap-2">
           <div className="w-3/4 lg:w-1/2">

--- a/packages/components/src/music/components/Matches.tsx
+++ b/packages/components/src/music/components/Matches.tsx
@@ -30,9 +30,11 @@ export function Matches({
 
   return (
     <div className="flex flex-col gap-4">
-      <p className="w-full text-dark-gray-500 dark:text-mint-200">
-        Review and approve/deny the songs matched below
-      </p>
+      {filteredMatches.length > 0 && state === "INCOMING" && (
+        <p className="w-full text-dark-gray-500 dark:text-mint-200">
+          Review and approve/deny the songs matched below
+        </p>
+      )}
       {filteredMatches.length === 0 && (
         <div className="mt-16 flex w-full flex-col items-center gap-2">
           <div className="w-3/4 lg:w-1/2">

--- a/packages/components/src/song-request/components/Matches.tsx
+++ b/packages/components/src/song-request/components/Matches.tsx
@@ -35,9 +35,11 @@ export function Matches({
 
   return (
     <div className="flex flex-col gap-4">
-      <p className="w-full text-dark-gray-500 dark:text-mint-200">
-        Review and approve/deny the songs matched below
-      </p>
+      {filteredMatches.length > 0 && state === "INCOMING" && (
+        <p className="w-full text-dark-gray-500 dark:text-mint-200">
+          Review and approve/deny the songs matched below
+        </p>
+      )}
       {filteredMatches.length === 0 && (
         <div className="mt-16 flex w-full flex-col items-center gap-2">
           <div className="w-3/4 lg:w-1/2">


### PR DESCRIPTION
## Description

<!--- What does this PR do? -->

The status prompts on the matching pages always showed whether there were matches displayed or not and whether there was action to take or not. This PR fixes that.

## GitHub Issue

Closes #480 

## Type of changes

<!--- Select all that apply -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Global styling changes
- [ ] New package(s)
- [ ] New dependencies
- [ ] Project configuration
- [ ] Environment variable update
- [ ] Database migration
- [ ] CI/CD changes (changing github actions or deployment scripts)

## Checklist:

<!--- Select all that apply -->

- [x] I verified my changes work in the local environment
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I verified my changes work in the preview environment
